### PR TITLE
Added timeout parameter to swift connection.

### DIFF
--- a/api/src/main/resources/swift_repository.py
+++ b/api/src/main/resources/swift_repository.py
@@ -103,6 +103,7 @@ class SwiftRepository(object):
                                                    key=self._connection['key'],
                                                    tenant_name=self._connection[
                                                        'account'],
-                                                   authurl=self._connection['auth_url'])
+                                                   authurl=self._connection['auth_url'],
+                                                   timeout=30)
 
         return connection


### PR DESCRIPTION
If applied, this commit will apply an http timeout to connections to swift.

Connections were seen to hang indefinitely when connection to swift was interrupted, and not recover.

Ticket: PNDA-1811.