### PR TITLE
PNDA-4669: Package repository service returns HTTP 500 instead of 404 for missing package

### DIFF
--- a/api/src/main/resources/fs_repository.py
+++ b/api/src/main/resources/fs_repository.py
@@ -24,6 +24,7 @@ either express or implied.
 import os
 import logging
 
+
 class FsRepository(object):
     def __init__(self, location):
         self._location = location
@@ -49,9 +50,12 @@ class FsRepository(object):
 
     def download_package(self, package):
         logging.debug("download_package %s", package)
-        with open("%s" % package, "rb") as in_file:
-            package_data = in_file.read()
-        return package_data
+        try:
+            with open("%s" % package, "rb") as in_file:
+                package_data = in_file.read()
+            return package_data
+        except IOError:
+            raise IOError("Package Not Found.")
 
     def put_package(self, package_name, package_contents):
         logging.debug("uploading package %s", package_name)
@@ -60,5 +64,7 @@ class FsRepository(object):
 
     def delete_package(self, package):
         logging.debug("delete_package %s", package)
-
-        os.remove(self._location['path']+"/"+package)
+        try:
+            os.remove(self._location['path']+"/"+package)
+        except IOError:
+            raise IOError("Package Not Found.")

--- a/api/src/main/resources/package_repository_rest_server.py
+++ b/api/src/main/resources/package_repository_rest_server.py
@@ -88,7 +88,7 @@ class PackageRepositoryRestServer(object):
                     self.set_header('Content-Type', content_type)
                 try:
                     self.write(package_manager.read_package(path, self.get_argument("user.name")))
-                except KeyError:
+                except (KeyError, IOError):
                     logging.error(traceback.format_exc())
                     self.write("404 not found")
                     self.set_status(404)


### PR DESCRIPTION
# Problem Statement:
PNDA-4669: Package repository service returns HTTP 500 instead of 404 for missing package

# Changes:
Added exception handling for FsRepository while reading/downloading the package and deleting the package.

# Test details
RHEL - PICO - CDH & HDP