### PR TITLE
[PNDA-4955] Added logic to prevent duplicate group users appending

### DIFF
--- a/api/src/main/resources/package_manager.py
+++ b/api/src/main/resources/package_manager.py
@@ -48,7 +48,8 @@ class PackageManager(object):
             try:
                 groups = [g.gr_name for g in grp.getgrall() if user in g.gr_mem]
                 gid = pwd.getpwnam(user).pw_gid
-                groups.append(grp.getgrgid(gid).gr_name)
+                if gid != grp.getgrgid(gid).gr_gid:
+                    groups.append(grp.getgrgid(gid).gr_name)
             except:
                 raise exceptiondef.Forbidden('Failed to find details for user "%s"' % user)
         return groups


### PR DESCRIPTION
Added logic to prevent duplicate group users appending in package_manager.py file for package repository. This is the only issue which we have seen while integrating package repository service with Kubernetes. 
